### PR TITLE
[kubeservice-custom-limitrange] add auto install crds

### DIFF
--- a/charts/kubeservice-custom-limitrange/Chart.yaml
+++ b/charts/kubeservice-custom-limitrange/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kubeservice-custom-limitrange/templates/crds/custom.cmss.com_customlimitranges.yaml
+++ b/charts/kubeservice-custom-limitrange/templates/crds/custom.cmss.com_customlimitranges.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: customlimitranges.custom.cmss.com
+spec:
+  group: custom.cmss.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+          - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CustomLimitRangeSpec defines the desired state of CustomLimitRange
+              type: object
+              properties:
+                limitrange:
+                  required:
+                  - type
+                  type: object
+                  description: limitrange pattern
+                  properties:
+                    default:
+                      properties:
+                        egress-bandwidth:
+                          type: string
+                          pattern: "^[1-9][0-9]*M$|^[1-9][0-9]*G$|^[1-9][0-9]*k$|^[1-9][0-9]*P$|^[1-9][0-9]*T$"
+                        ingress-bandwidth:
+                          type: string
+                          pattern: "^[1-9][0-9]*M$|^[1-9][0-9]*G$|^[1-9][0-9]*k$|^[1-9][0-9]*P$|^[1-9][0-9]*T$"
+                      type: object
+                    max:
+                      properties:
+                        egress-bandwidth:
+                          type: string
+                          pattern: "^[1-9][0-9]*M$|^[1-9][0-9]*G$|^[1-9][0-9]*k$|^[1-9][0-9]*P$|^[1-9][0-9]*T$"
+                        ingress-bandwidth:
+                          type: string
+                          pattern: "^[1-9][0-9]*M$|^[1-9][0-9]*G$|^[1-9][0-9]*k$|^[1-9][0-9]*P$|^[1-9][0-9]*T$"
+                      type: object
+                    min:
+                      properties:
+                        egress-bandwidth:
+                          type: string
+                          pattern: "^[1-9][0-9]*M$|^[1-9][0-9]*G$|^[1-9][0-9]*k$|^[1-9][0-9]*P$|^[1-9][0-9]*T$"
+                        ingress-bandwidth:
+                          type: string
+                          pattern: "^[1-9][0-9]*M$|^[1-9][0-9]*G$|^[1-9][0-9]*k$|^[1-9][0-9]*P$|^[1-9][0-9]*T$"
+                      type: object
+                    type:
+                      type: string
+                      default: "pod"
+                      enum: ["pod", "Pod", "POD"]
+            status:
+              description: CustomLimitRangeStatus defines the observed state of CustomLimitRange
+              type: object
+      additionalPrinterColumns:
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+  scope: Namespaced
+  names:
+    plural: customlimitranges
+    singular: customlimitrange
+    kind: CustomLimitRange
+    listKind: CustomLimitRangeList
+    shortNames:
+    - clr
+{{- end }}

--- a/charts/kubeservice-custom-limitrange/values.yaml
+++ b/charts/kubeservice-custom-limitrange/values.yaml
@@ -7,6 +7,9 @@ cert-manager:
   enabled: true
   installCRDs: true
 
+# install CRDs
+installCRDs: true
+
 replicaCount: 2
 
 image:


### PR DESCRIPTION
### What type of PR is this?
/kind feature
/kind fix

- [x] Unittest
- [x] Coverage 80%+
- [x] Build Success

### What this PR does / why we need it:
add auto install crds on kubeservice-custom-limitrange helm charts